### PR TITLE
cargo: use streams develop branch, do not use iota-core explicitly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,7 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow = { version = "1.0", default-features = false }
-iota-streams = { git = "https://github.com/iotaledger/streams", rev = "04cfe80"}
-iota-core = { git = "https://github.com/iotaledger/iota.rs", rev = "74fa529" }
+iota-streams = { git = "https://github.com/iotaledger/streams", branch = "develop" }
 tokio = { version = "^0.2", features = ["full"] }
 async-trait = "0.1.30"
 chrono = "0.4"

--- a/src/gateway/publisher.rs
+++ b/src/gateway/publisher.rs
@@ -8,14 +8,16 @@ use crate::{
 
 use anyhow::Result;
 use iota_streams::{
-    app::transport::tangle::{
-        client::{Client as StreamsClient, SendTrytesOptions},
-        PAYLOAD_BYTES,
+    app::transport::{
+        TransportOptions,
+        tangle::{
+            client::{Client as StreamsClient, SendTrytesOptions},
+            PAYLOAD_BYTES,
+        },
     },
     app_channels::api::tangle::{Address, Author},
 };
 
-use iota::client as iota_client;
 use std::string::ToString;
 
 ///
@@ -41,14 +43,8 @@ impl Channel {
         send_opt.min_weight_magnitude = mwm;
         send_opt.local_pow = local_pow;
 
-        let client: StreamsClient = StreamsClient::new(
-            send_opt,
-            iota_client::ClientBuilder::new()
-                .node(&node)
-                .unwrap()
-                .build()
-                .unwrap(),
-        );
+        let mut client = StreamsClient::new_from_url(&node);
+        client.set_send_options(send_opt);
 
         let author = Author::new(&seed, "utf-8", PAYLOAD_BYTES, false, client);
 


### PR DESCRIPTION
`develop` branch of `iota-streams` repo should be good enough as it might contain some important updates/fixes and it won't break API anytime soon. Also, you rarely should list `iota-core` as dependency explicitly, you can create a client use streams API only.

This PR fixes the issue with `iota-core` using `reqwest` crate which in turn caused issues by infinitely looping after a certain number of requests.