### PR TITLE
add repository field to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ name = "gateway_core"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = { version = "1.0", default-features = false }
+anyhow = { version = "1.0.34", default-features = false }
 iota-streams = { git = "https://github.com/iotaledger/streams", branch = "develop" }
 tokio = { version = "^0.2", features = ["full"] }
 async-trait = "0.1.30"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["AleBuser <alebuser.98@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0/MIT"
+repository = "https://github.com/iot2tangle/streams-gateway-core"
 readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
~~@AleBuser wants to use `Cargo.lock` to freeze the codebase for the competition.~~
~~therefore this PR should be merged only after competition~~

this PR adds a `repository` field to `Cargo.toml`
avoids breaking BitBake builds